### PR TITLE
Added support for `pragmaMatcher` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ The following are the available options with their default values.
             {
                 "removeConsole":  true,
                 "removeDebugger": true,
-                "removePragma":   true
+                "removePragma":   true,
+                "pragmaMatcher":  "^\\s?<(\/?)([\\w\\d\\-]*)>\\s*$"
             }
         ]
     ]
@@ -142,3 +143,23 @@ If you wish to leave in all console statements, set this to false.
 If you wish to leave in all debugger statements, set this to false.
 #### `removePragma`
 If you wish to leave in all pragmas-wrapped code, stet this to false.
+#### `pragmaMatcher`
+May be a regexp string or string array.
+If it is a regexp string, it should have two capture groups: first determines closing pragma, second — pragma name.
+If it is a string array, it should contain names of pragmas, which will be removed.
+
+Remove only `debug` and `lol` pragmas:
+
+````json
+{
+    "pragmaMatcher": "^\\s?<(\\/?)(debug|lol)>\\s*$"
+}
+````
+
+Exactly the same as before, but as array:
+
+````json
+{
+    "pragmaMatcher": ["debug", "lol"]
+}
+````

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -115,11 +115,30 @@ const fetchDisabledLines = function(comments, disabledRegex){
      return false;
  };
 
+/**
+ * Get a valid pragma matcher.
+ * @param  {Object} defaults Default options.
+ * @param  {Object} opts     Actual options.
+ * @return {Object}          Pragma matcher options.
+ */
+const getPragmaMatcher = function(defaults, opts){
+    if (typeof opts.pragmaMatcher === 'string') {
+        return { pragmaMatcher: new RegExp(opts.pragmaMatcher) };
+    } else if (Object.prototype.toString.call(opts.pragmaMatcher) === '[object RegExp]') {
+        return { pragmaMatcher: opts.pragmaMatcher };
+    } else if (Array.isArray(opts.pragmaMatcher)) {
+        return { pragmaMatcher: new RegExp(String.raw`^\s?<(\/?)(${opts.pragmaMatcher.join('|')})>\s*$`) };
+    } else {
+        return { pragmaMatcher: defaults.pragmaMatcher };
+    }
+};
+
 
 module.exports = {
     fetchDisabledLines,
     fetchPragmas,
     isInsidePragma,
     isLineDisableComment,
-    isOnDisabledLine
+    isOnDisabledLine,
+    getPragmaMatcher
 };

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ module.exports = function(babel) {
         visitor: {
             Program(path, state) {
                 // If no options are missing, use our defaults.
-                state.opts = Object.assign({}, DEFAULTS, state.opts);
+                state.opts = Object.assign({}, DEFAULTS, state.opts, helpers.getPragmaMatcher(DEFAULTS, state.opts));
                 const comments = path.parent && path.parent.comments ? path.parent.comments : [];
                 const disabledLines = helpers.fetchDisabledLines(comments, state.opts.disableLineMatcher);
                 const pragmaRegions = state.opts.removePragma ? helpers.fetchPragmas(comments, state.opts.pragmaMatcher) : [];

--- a/test/fixtures/ignore-disabled-lines/expected.js
+++ b/test/fixtures/ignore-disabled-lines/expected.js
@@ -8,12 +8,12 @@ let evenOtherName = 'Amy';
   let foo = name;console.log(foo);
 })(); // groundskeeper-willie-disable-line
 
-console.log(`Hi ${ otherName }`); // groundskeeper-willie-disable-line
-console.log(`Hi ${ evenOtherName }`); /* groundskeeper-disable-line*/
+console.log(`Hi ${otherName}`); // groundskeeper-willie-disable-line
+console.log(`Hi ${evenOtherName}`); /* groundskeeper-disable-line*/
 
-console.warn(`Hi ${ otherName }`); // groundskeeper-willie-disable-line
-console.warn(`Hi ${ evenOtherName }`); // groundskeeper-disable-line
+console.warn(`Hi ${otherName}`); // groundskeeper-willie-disable-line
+console.warn(`Hi ${evenOtherName}`); // groundskeeper-disable-line
 
-console.error(`Hi ${ otherName }`); // groundskeeper-willie-disable-line
-console.error(`Hi ${ evenOtherName }`); // groundskeeper-disable-line
+console.error(`Hi ${otherName}`); // groundskeeper-willie-disable-line
+console.error(`Hi ${evenOtherName}`); // groundskeeper-disable-line
 debugger; // groundskeeper-willie-disable-line

--- a/test/fixtures/remove-debugger-calls/expected.js
+++ b/test/fixtures/remove-debugger-calls/expected.js
@@ -1,5 +1,5 @@
 function like(brand) {
     let name = 'Fry';
 
-    return `${ name } likes ${ brand }`;
+    return `${name} likes ${brand}`;
 }

--- a/test/fixtures/remove-pragmas/expected.js
+++ b/test/fixtures/remove-pragmas/expected.js
@@ -1,7 +1,6 @@
 module.exports = {
     prodCode: {
         crew: ['Leela', 'Fry', 'Bender']
-    }
-};
+    } };
 module.exports.someArrayValues = ['Nibbler does', 'eat kittens'];
 module.epxorts.someOtherThings = [];

--- a/test/fixtures/respect-pragmaMatcher-option-as-array/.babelrc
+++ b/test/fixtures/respect-pragmaMatcher-option-as-array/.babelrc
@@ -1,0 +1,4 @@
+{
+  "plugins": [
+      ["../../../src", { "pragmaMatcher": ["debug", "lol"] }]]
+}

--- a/test/fixtures/respect-pragmaMatcher-option-as-array/actual.js
+++ b/test/fixtures/respect-pragmaMatcher-option-as-array/actual.js
@@ -1,0 +1,16 @@
+function love(fry) {
+    //<editor-fold desc="Fold">
+    one();
+    //<debug>
+    console.log(`${ fry } loves you!`);
+    //</debug>
+    two();
+    //<lol>
+    console.log('Oh-oh, my girlfriend was crushed by Spacemarine');
+    //</lol>
+    three();
+    //</editor-fold>
+    //<pragma>
+    return `${ fry } loves you!`;
+    //</pragma>
+}

--- a/test/fixtures/respect-pragmaMatcher-option-as-array/expected.js
+++ b/test/fixtures/respect-pragmaMatcher-option-as-array/expected.js
@@ -1,0 +1,12 @@
+function love(fry) {
+    //<editor-fold desc="Fold">
+    one();
+
+    two();
+
+    three();
+    //</editor-fold>
+    //<pragma>
+    return `${fry} loves you!`;
+    //</pragma>
+}

--- a/test/fixtures/respect-pragmaMatcher-option-as-regexp-string/.babelrc
+++ b/test/fixtures/respect-pragmaMatcher-option-as-regexp-string/.babelrc
@@ -1,0 +1,4 @@
+{
+  "plugins": [
+      ["../../../src", { "pragmaMatcher": "^\\s?<(\\/?)(debug|lol)>\\s*$" }]]
+}

--- a/test/fixtures/respect-pragmaMatcher-option-as-regexp-string/actual.js
+++ b/test/fixtures/respect-pragmaMatcher-option-as-regexp-string/actual.js
@@ -1,0 +1,16 @@
+function love(fry) {
+    //<editor-fold desc="Fold">
+    one();
+    //<debug>
+    console.log(`${ fry } loves you!`);
+    //</debug>
+    two();
+    //<lol>
+    console.log('Oh-oh, my girlfriend was crushed by Spacemarine');
+    //</lol>
+    three();
+    //</editor-fold>
+    //<pragma>
+    return `${ fry } loves you!`;
+    //</pragma>
+}

--- a/test/fixtures/respect-pragmaMatcher-option-as-regexp-string/expected.js
+++ b/test/fixtures/respect-pragmaMatcher-option-as-regexp-string/expected.js
@@ -1,0 +1,12 @@
+function love(fry) {
+    //<editor-fold desc="Fold">
+    one();
+
+    two();
+
+    three();
+    //</editor-fold>
+    //<pragma>
+    return `${fry} loves you!`;
+    //</pragma>
+}

--- a/test/fixtures/respect-removeDebugger-option/expected.js
+++ b/test/fixtures/respect-removeDebugger-option/expected.js
@@ -1,4 +1,4 @@
 function love(fry) {
     debugger;
-    return `${ fry } loves you!`;
+    return `${fry} loves you!`;
 }

--- a/test/fixtures/respect-removePragma-option/expected.js
+++ b/test/fixtures/respect-removePragma-option/expected.js
@@ -1,5 +1,5 @@
 function love(fry) {
     //<pragma>
-    return `${ fry } loves you!`;
+    return `${fry} loves you!`;
     //</pragma>
 }


### PR DESCRIPTION
Now the plugin supports passing `pragmaMatcher` option to the options object in two ways: as regexp string, and as a string array. If string was passed, it will be parsed as regexp, if string array — pragma matcher regexp will be built internally, with concatenation using `|` of all given strings as substitution in second capture group (`pragmaName`).